### PR TITLE
[PKG-3023] libvpx 1.13.1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,38 +6,40 @@ set -ex
 cp $BUILD_PREFIX/share/libtool/build-aux/config.* .
 
 if [[ $(uname) == MSYS* ]]; then
-  if [[ ${ARCH} == 32 ]]; then
-    HOST_BUILD="--host=i686-w64-mingw32 --build=i686-w64-mingw32"
-  else
     HOST_BUILD="--host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32"
-  fi
-  PREFIX=${PREFIX}/Library/mingw-w64
+    PREFIX=${PREFIX}/Library/mingw-w64
 fi
 
 if [[ ${target_platform} == linux-* ]]; then
-  LDFLAGS="$LDFLAGS -pthread"
+    LDFLAGS="$LDFLAGS -pthread"
 fi
 
 CPU_DETECT=""
 if [[ ${target_platform} == osx-* ]]; then
-  CPU_DETECT="${CPU_DETECT} --disable-avx512 --disable-runtime-cpu-detect"
+    CPU_DETECT="${CPU_DETECT} --disable-avx512 --disable-runtime-cpu-detect"
+    if [[ ${target_platform} == osx-arm64 ]]; then
+        TARGET="--target=arm64-darwin20-gcc"
+        export CROSS=arm64-apple-darwin20.0.0-
+        # -fembed-bitcode conflicts with a conda-forge LD option (-dead_strip_dylibs)
+        sed -i.bak "/check_add_ldflags -fembed-bitcode/d" build/make/configure.sh
+    fi
 else
-  CPU_DETECT="${CPU_DETECT} --enable-runtime-cpu-detect"
+    CPU_DETECT="${CPU_DETECT} --enable-runtime-cpu-detect"
 fi
 
-./configure --prefix=${PREFIX} ${HOST_BUILD} \
-            --as=yasm                    \
-            --enable-shared              \
-            --disable-static             \
-            --disable-install-docs       \
-            --disable-install-srcs       \
-            --enable-vp8                 \
-            --enable-postproc            \
-            --enable-vp9                 \
-            --enable-vp9-highbitdepth    \
-            --enable-pic                 \
-            ${CPU_DETECT}                \
-            --enable-experimental || { cat config.log; exit 1; }
+./configure --prefix=${PREFIX} ${TARGET} \
+--as=yasm                    \
+--enable-shared              \
+--disable-static             \
+--disable-install-docs       \
+--disable-install-srcs       \
+--enable-vp8                 \
+--enable-postproc            \
+--enable-vp9                 \
+--enable-vp9-highbitdepth    \
+--enable-pic                 \
+${CPU_DETECT}                \
+--enable-experimental || { cat config.log; exit 1; }
 
 make -j${CPU_COUNT} ${VERBOSE_AT}
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,17 +17,11 @@ fi
 CPU_DETECT=""
 if [[ ${target_platform} == osx-* ]]; then
     CPU_DETECT="${CPU_DETECT} --disable-avx512 --disable-runtime-cpu-detect"
-    if [[ ${target_platform} == osx-arm64 ]]; then
-        TARGET="--target=arm64-darwin20-gcc"
-        export CROSS=arm64-apple-darwin20.0.0-
-        # -fembed-bitcode conflicts with a conda-forge LD option (-dead_strip_dylibs)
-        sed -i.bak "/check_add_ldflags -fembed-bitcode/d" build/make/configure.sh
-    fi
 else
     CPU_DETECT="${CPU_DETECT} --enable-runtime-cpu-detect"
 fi
 
-./configure --prefix=${PREFIX} ${TARGET} \
+./configure --prefix=${PREFIX} ${HOST_BUILD} \
 --as=yasm                    \
 --enable-shared              \
 --disable-static             \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libvpx" %}
-{% set version = "1.11.0" %}
+{% set version = "1.13.1" %}
 {% set p = "m2-" if win else "" %}
 
 package:
@@ -7,8 +7,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://download.videolan.org/contrib/vpx/libvpx-{{ version }}.tar.gz
-  sha256: 965e51c91ad9851e2337aebcc0f517440c637c506f3a03948062e3d5ea129a83
+  url: https://download.videolan.org/contrib/vpx/{{ name }}-{{ version }}.tar.gz
+  sha256: 00dae80465567272abd077f59355f95ac91d7809a2d3006f9ace2637dd429d14
 
 build:
   number: 0


### PR DESCRIPTION
**Current package info**


| Channel | Downloads | Version | Platforms | License |
| --- | --- | --- | --- | --- |
| main | [![Conda Downloads](https://img.shields.io/conda/dn/main/libvpx.svg)](https://anaconda.org/main/libvpx) | [![Conda Version](https://img.shields.io/conda/vn/main/libvpx.svg)](https://anaconda.org/main/libvpx) | [![Conda Platforms](https://img.shields.io/conda/pn/main/libvpx.svg)](https://anaconda.org/main/libvpx) | ![Conda License](https://img.shields.io/conda/l/main/libvpx) |

Changelog: https://chromium.googlesource.com/webm/libvpx/+/10b9492dcf05b652e2e4b370e205bd605d421972/CHANGELOG
License: https://chromium.googlesource.com/webm/libvpx/+/refs/tags/v1.13.1/LICENSE
Requirements: https://chromium.googlesource.com/webm/libvpx/+/refs/tags/v1.13.1/README#10

Actions:
1. Remove win32 support from the build script
2. Add osx-arm64 stuff to build.sh (from the conda-forge recipe)

Notes:
- to address CVE-2023-5217 with a score of **8.8**.