### PR TITLE
Update version to 1.15.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,14 @@
 {% set name = "libvpx" %}
-{% set version = "1.13.1" %}
-{% set p = "m2-" if win else "" %}
+{% set version = "1.15.2" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://download.videolan.org/contrib/vpx/{{ name }}-{{ version }}.tar.gz
-  sha256: 00dae80465567272abd077f59355f95ac91d7809a2d3006f9ace2637dd429d14
+  - git_url: https://chromium.googlesource.com/webm/{{ name }}
+    git_ref: v{{ version }}
+    git_depth: 1
 
 build:
   number: 0
@@ -21,29 +21,25 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - posix                     # [win]
-    - {{ p }}git
-    - {{ p }}make
-    - {{ p }}libtool
-    - m2w64-toolchain          # [win]
+    - git
+    - make
+    - libtool
     - yasm
-  run:
-    - m2w64-gcc-libs           # [win]
 
 test:
   requires:
     - conda-build
   commands:
     - test -f ${PREFIX}/lib/libvpx${SHLIB_EXT}
-    - ${PREFIX}/bin/vpxenc --help  # [build_platform == target_platform]
-    - ${PREFIX}/bin/vpxdec --help  # [build_platform == target_platform]
+    - ${PREFIX}/bin/vpxenc --help
     - conda inspect linkages -p $PREFIX libvpx    # [not win]
     - conda inspect objects -p $PREFIX libvpx     # [osx]
 
 about:
-  home: https://www.webmproject.org/
+  home: https://www.webmproject.org
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
@@ -55,7 +51,7 @@ about:
     the video coding formats VP8 and VP9, and for AV1 a
     special fork named libaom that was stripped of
     backwards compatibility.
-  doc_url: http://www.webmproject.org/vp9/
+  doc_url: https://www.webmproject.org/vp9
   dev_url: https://chromium.googlesource.com/webm/libvpx
 
 extra:


### PR DESCRIPTION
libvpx 1.15.2

**Destination channel:** Main

### Links

- [PKG-10036](https://anaconda.atlassian.net/browse/PKG-10036) 
- [Upstream repository](https://chromium.googlesource.com/webm/libvpx)

### Explanation of changes:

- Update version number
- Remove dependencies for windows


[PKG-10036]: https://anaconda.atlassian.net/browse/PKG-10036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ