### PR TITLE
v1.16.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libvpx" %}
-{% set version = "1.15.2" %}
+{% set version = "1.16.0" %}
 
 package:
   name: {{ name }}
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [win or s390x]
+  skip: True  # [win]
   run_exports:
     # new so names and compatibility changes on minor version
     # https://abi-laboratory.pro/tracker/timeline/libvpx/


### PR DESCRIPTION
libvpx v1.16.0

**Destination channel:** defaults

### Links

- [PKG-13113](https://anaconda.atlassian.net/browse/PKG-13113) 
- [Upstream repository](https://chromium.googlesource.com/webm/libvpx/+/refs/tags/v1.16.0)
- [Upstream changelog/diff](https://chromium.googlesource.com/webm/libvpx/+/refs/tags/v1.16.0)

### Explanation of changes:

- Bump version
- Remove stale selector


[PKG-13113]: https://anaconda.atlassian.net/browse/PKG-13113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ